### PR TITLE
Guard against a null colorHex

### DIFF
--- a/iLevel.lua
+++ b/iLevel.lua
@@ -366,7 +366,9 @@ do -- Update saved item data per slot and refresh text strings at the same time
 							local gemStat = TooltipScanItem(gemLink, nil, true, slotId)
 							if db.color then
 								local _, _, colorHex = string.find(gemLink, "|cff(%x*)")
-								frame[slotId].currentSockets = strtrim(frame[slotId].currentSockets .. (gemStat and ("\n|cff" .. colorHex .. "|T" .. sockets[t] .. ":0:0:0:0:32:32:2:30:2:30|t " .. gemStat .. "|r") or ""))
+								if colorHex then
+									frame[slotId].currentSockets = strtrim(frame[slotId].currentSockets .. (gemStat and ("\n|cff" .. colorHex .. "|T" .. sockets[t] .. ":0:0:0:0:32:32:2:30:2:30|t " .. gemStat .. "|r") or ""))
+								end
 							else
 								frame[slotId].currentSockets = strtrim(frame[slotId].currentSockets .. (gemStat and ("\n|T" .. sockets[t] .. ":0:0:0:0:32:32:2:30:2:30|t " .. gemStat) or ""))
 							end


### PR DESCRIPTION
I don't write addons, so my apologies if the explanation ends up not making a ton of sense, but I think what's happening is that some items like [Cyrce's Circlet](https://www.wowhead.com/item=228411/cyrces-circlet) have sockets that accept special gems instead of the regular ones and that breaks ... something. This is the error being thrown:

```
iLevel/iLevel.lua:369: attempt to concatenate local 'colorHex' (a nil value)
[iLevel/iLevel.lua]:369: in function <iLevel/iLevel.lua:331>
```

I fixed this for myself by adding a null check, so here's a PR with the same change. 🙏